### PR TITLE
fix for the end of count text display not showing properly

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
         // If the count down is over, write some text 
         if (distance < 0) {
             clearInterval(x);
-            document.getElementById("demo").innerHTML = "<Hello, Handsome!>";
+            document.getElementById("demo").innerHTML = "Hello, Handsome!";
         }
         }, 1000);
 


### PR DESCRIPTION
The JS was trying to create a tag <hello> instead of displaying the text when the count ended causing no text to display at all. By removing the <> symbols, the text now correctly displays when the timer gets to 0 💚